### PR TITLE
Fix: set position to (float.MinValue, float.MinValue) when player is dead

### DIFF
--- a/src/EdcHost/EdcHost.cs
+++ b/src/EdcHost/EdcHost.cs
@@ -222,10 +222,26 @@ partial class EdcHost : IEdcHost
                             heightOfChunks: heightOfChunks,
                             hasBed: _game.Players[i].HasBed,
                             hasBedOpponent: _game.Players.Any(player => player.HasBed && player.PlayerId != _game.Players[i].PlayerId),
-                            positionX: _game.Players[i].PlayerPosition.X,
-                            positionY: _game.Players[i].PlayerPosition.Y,
-                            positionOpponentX: _game.Players[(i == 0) ? 1 : 0].PlayerPosition.X,
-                            positionOpponentY: _game.Players[(i == 0) ? 1 : 0].PlayerPosition.Y,
+                            positionX: (
+                                _game.Players[i].IsAlive == true ?
+                                _game.Players[i].PlayerPosition.X :
+                                float.MinValue
+                            ),
+                            positionY: (
+                                _game.Players[i].IsAlive == true ?
+                                _game.Players[i].PlayerPosition.Y :
+                                float.MinValue
+                            ),
+                            positionOpponentX: (
+                                _game.Players[(i == 0) ? 1 : 0].IsAlive == true ?
+                                _game.Players[(i == 0) ? 1 : 0].PlayerPosition.X :
+                                float.MinValue
+                            ),
+                            positionOpponentY: (
+                                _game.Players[(i == 0) ? 1 : 0].IsAlive == true ?
+                                _game.Players[(i == 0) ? 1 : 0].PlayerPosition.Y :
+                                float.MinValue
+                            ),
                             agility: _game.Players[i].ActionPoints,
                             health: _game.Players[i].Health,
                             maxHealth: _game.Players[i].MaxHealth,


### PR DESCRIPTION
## What does this PR do?

This does not change a player's position. Just send a "position" to player, that means, the player is dead.

## Which issues does this PR resolve?



## Checklist before merging

Thank you for your contribution to the repository. 
Before submitting this PR, please make sure:

- [ ] Your code builds clean without any errors or warnings
- [ ] Your code follows the code style of [Common C# code conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
- [ ] You have tested all functions
- [ ] You have not used code without license
- [ ] You have added statement for third-party code
